### PR TITLE
changed table styling (light gray odd rows, border lines)

### DIFF
--- a/_includes/style.html
+++ b/_includes/style.html
@@ -1,0 +1,20 @@
+<style type="text/css">
+
+table {
+    border-collapse: collapse;
+}
+
+thead {
+    border-top: solid #DCDCDC;
+    border-bottom: solid #DCDCDC;
+}
+
+tr.odd {
+    background-color: #F8F8F8;
+}
+
+tr:last-child {
+    border-bottom: solid #DCDCDC;
+}
+
+</style>

--- a/_output.yml
+++ b/_output.yml
@@ -9,4 +9,4 @@ html_document:
         after_body: _includes/footer.html
     theme: lumen # lumen or simplex or sandstone
     # highlight: pygments # or textmate or tango or default?
-    mathjax: "http://example.com/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+    mathjax: "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"

--- a/_output.yml
+++ b/_output.yml
@@ -5,7 +5,8 @@ html_document:
         collapsed: false
         smooth_scroll: false
     include:
+        in_header: _includes/style.html
         after_body: _includes/footer.html
     theme: lumen # lumen or simplex or sandstone
     # highlight: pygments # or textmate or tango or default?
-    #css: _includes/style.css
+    mathjax: "http://example.com/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"


### PR DESCRIPTION
Table rows now have a very light gray for odd rows. Tables have borders on top and bottom for the header row and the bottom border for the last row.

Added MathJax support for nice (future) equations.