### PR TITLE
Added note about missing even project work days

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -100,6 +100,6 @@ You should be aware of the University of Toronto Code of Behaviour on Academic M
 | Final project work        | Project, Group      | Dec 15     | 32    |
 | Participation             | Individual          | -          | 8     |
 
-Students can be absent from two lectures without losing any participation marks. After that, students will lose 1 mark per missed lecture.
+Students can be absent from two lectures (*including* project work days) without losing any participation marks. After that, students will lose 1 mark per missed lecture.
 
 Assessments will be distributed and submitted in the R Markdown format via Blackboard or GitHub. Assessments will be handed out on Thursdays and due 11:59 pm on the Tuesday eight weekdays later. _There will be a penalty of 5% per day (including week-ends) for late submissions._


### PR DESCRIPTION
For the participation marks. So they know that even the project work days we expect them to come.