### PR TITLE
remove output yaml option

### DIFF
--- a/lec01-introduction.Rmd
+++ b/lec01-introduction.Rmd
@@ -1,7 +1,6 @@
 ---
 title: "Introduction to course"
 author: "Joel Östblom & Ahmed Hasan"
-output: pdf_document
 ---
 
 ```{r echo=FALSE, results='hide', message=FALSE, warning=FALSE}

--- a/lec02-basic-r.Rmd
+++ b/lec02-basic-r.Rmd
@@ -1,7 +1,6 @@
 ---
 title: 'Introduction to R: Vectors, functions, data frames'
 author: "Joel Östblom & Ahmed Hasan"
-output: pdf_document
 ---
 
 **Copyright (c) Data Carpentry**


### PR DESCRIPTION
As per @joelostblom question in #200, the reason the image isn't showing is because the YAML header option `output` was set to `pdf_document`... which generates a tex file that R tries to generate into a pdf... but since the travis environment doesn't have TeX installed, it throws an error and doesn't finish creating everything. Not sure why travis didn't catch that...

Anyway, you guys don't need to set the output option in the YAML header.