### PR TITLE
Fix 404 bug

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -30,13 +30,13 @@ navbar:
     - text: 'Oct. 03: Mixed effects models'
       href: lec08-linear-mixed-effects-models.html
     - text: 'Oct. 08: Model Selection'
-      href: lec09-model-selection.Rmd
+      href: lec09-model-selection.html
     - text: 'Oct. 10: Multivariate stats'
       # href: lec10-multivariate-stats.html
     - text: 'Oct. 15: Spatial stats'
       # href: lec11-spatial-stats.html
     - text: 'Oct. 17: Simulating data: Randomization tests'
-      href: lec12-randomization-tests.Rmd
+      href: lec12-randomization-tests.html
     - text: 'Oct. 22: Ecological modelling'
       # href: lec13-ecological-modelling.html
     - text: 'Oct. 24: Evolutionary modelling'


### PR DESCRIPTION
Lectures 9 and 12 were giving 404 errors since they were set to .Rmd and not .html - this corrects the issue